### PR TITLE
phpuk: Replace wardrobe with cloakroom

### DIFF
--- a/phpuk.md
+++ b/phpuk.md
@@ -5,15 +5,15 @@ Website: [phpconference.co.uk](http://phpconference.co.uk/)
 ### Tips
 
 - The day before the conference there is always a pre-conference meetup/social. If you wait long enough, some batches of speakers will drop in after their dinner.
-- London in February means rainy days. But if you bring an umbrella, there is a free wardrobe service. Be kind to staff :-)
-- Brits like to queue. Queue to get your badge, queue to get food, queue to get your stuff from the wardrobe, ...
+- London in February means rainy days. But if you bring an umbrella, there is a free cloakroom service. Be kind to staff :-)
+- Brits like to queue. Queue to get your badge, queue to get food, queue to get your stuff from the cloakroom, ...
 - The location is called "The Brewery". There are some big rooms and several ways to access them. Take a different exit then the door you entered a room to discover all of them. Even the best explorers will get disorientated.
 - There is a multi-religion prayer room 🙏 very open to all people.
 - This conference is big. Up to 700 people attending. So if you want to see a session, make sure to have a seat 5 minutes before a session starts.
 - Food at lunch is amazingly delicious. But if you're hungry, the Whitecross Street has a nice street market with food stands. Delicious food being made there too.
 - The cheapest place to stay is the Travel Lodge. You will definitely run into people attending the conference in the lobby downstairs.
 - There's chilled water (and coffee?) at all times in the sponsor area and chill area.
-- Extremely useful tip I've tried myself: get your stuff from the wardrobe _before_ the closing keynote. This way you don't have to queue when everyone want their stuff at the same time after the closing keynote.
+- Extremely useful tip I've tried myself: get your stuff from the cloakroom _before_ the closing keynote. This way you don't have to queue when everyone want their stuff at the same time after the closing keynote.
 
 ### Drinks
 


### PR DESCRIPTION
In English (British English at least), a wardrobe tends to be a bit of furniture in a bedroom. In a venue, a service to store coats, umbrellas, luggage etc. is more likely to be known as a cloakroom service.